### PR TITLE
Doc fix

### DIFF
--- a/Intrinio.Realtime/Options/Trade.cs
+++ b/Intrinio.Realtime/Options/Trade.cs
@@ -39,7 +39,7 @@ public struct Trade
     /// <param name="underlyingPriceType">The scalar for underlying price.</param>
     /// <param name="price">The dollar price of the last trade.</param>
     /// <param name="size">The number of contacts for the trade.</param>
-    /// <param name="timestamp">The time that the trade was executed (a unix timestamp representing the number of seconds (or better) since the unix epoch).</param>
+    /// <param name="timestamp">The time that the trade was executed (a unix timestamp representing the number of nanoseconds since the unix epoch).</param>
     /// <param name="totalVolume">The running total trade volume for this contract today.</param>
     /// <param name="qualifiers">The exchange provided trade qualifiers. These can be used to classify whether a trade should be used, for example, for open, close, volume, high, or low.</param>
     /// <param name="askPriceAtExecution">The dollar price of the best ask at execution.</param>

--- a/Intrinio.Realtime/WebSocketClient.cs
+++ b/Intrinio.Realtime/WebSocketClient.cs
@@ -37,7 +37,7 @@ public abstract class WebSocketClient
     private readonly Func<Task> _tryReconnect;
     private readonly HttpClient _httpClient = new ();
     private const string ClientInfoHeaderKey = "Client-Information";
-    private const string ClientInfoHeaderValue = "IntrinioDotNetSDKv12.13";
+    private const string ClientInfoHeaderValue = "IntrinioDotNetSDKv12.14";
     private readonly ThreadPriority _mainThreadPriority;
     private readonly Thread[] _threads;
     private Thread? _receiveThread;

--- a/IntrinioRealTimeClient.nuspec
+++ b/IntrinioRealTimeClient.nuspec
@@ -2,7 +2,7 @@
 <package>
 	<metadata>
 		<id>IntrinioRealTimeClient</id>
-		<version>12.13.1</version>
+		<version>12.14.0</version>
 		<title>Intrinio SDK for Real-Time Stock and Option Prices</title>
 		<authors>Intrinio</authors>
 		<owners>Intrinio</owners>
@@ -10,7 +10,7 @@
 		<licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
 		<projectUrl>https://github.com/intrinio/intrinio-realtime-csharp-sdk</projectUrl>
 		<description>Intrinio provides real-time stock and option prices via a two-way WebSocket connection.</description>
-		<releaseNotes>Version 12.13.1 release.</releaseNotes>
+		<releaseNotes>Version 12.14.0 release.</releaseNotes>
 		<copyright>Copyright 2024 Intrinio</copyright>
 		<tags>fintech stocks options prices websocket real-time market finance</tags>
 		<dependencies>


### PR DESCRIPTION
Fixed documentation for timestamp property in the Option Trade constructor.  It previously said seconds since epoch, but is actually nanoseconds since epoch. No operational code changes.